### PR TITLE
improve kstat logic

### DIFF
--- a/ane/run.sh
+++ b/ane/run.sh
@@ -5,10 +5,10 @@ function logs(){
 }
 
 function status(){
-	kstat=$(lsmod | grep "ane" | head -n1 | awk '{print $1;}')
-	if [ "$kstat" = "ane" ]; then
+	kstat=$(lsmod | grep "^ane ")
+	if [ -n "$kstat" ]; then
 		lsmod | head -n1 # header
-		lsmod | grep "ane"
+		echo "$kstat"
 		echo "module is installed"
 	else
 		echo "module NOT installed"
@@ -16,9 +16,9 @@ function status(){
 }
 
 function uninstall(){
-	kstat=$(lsmod | grep "ane" | head -n1 | awk '{print $1;}')
-	if [ "$kstat" = "ane" ]; then
-		make uninstall 
+	kstat=$(lsmod | grep "^ane ")
+	if [ -n "$kstat" ]; then
+		make uninstall
 		echo "uninstalled module"
 	else
 		echo "module NOT installed"
@@ -26,8 +26,8 @@ function uninstall(){
 }
 
 function install(){
-	kstat=$(lsmod | grep "ane" | head -n1 | awk '{print $1;}')
-	if [ "$kstat" = "ane" ]; then
+	kstat=$(lsmod | grep "^ane ")
+	if [ -n "$kstat" ]; then
 		echo "already installed; removing then re-installing"
 		make uninstall && make && make install
 		logs


### PR DESCRIPTION
This is just a really minor/trivial thing. 

But....this logic
`kstat=$(lsmod | grep "ane" | head -n1 | awk '{print $1;}')`

Will search the entire output for the pattern `ane`

A slightly better way to check for that -- is do something like 
`kstat=$(lsmod | grep "^ane ")`

Which would only match the beginning of a line for the pattern `ane`  (followed by a space)
This is will generate a unique match for that module. 


Really nice work so far on your ane-related projects!!
